### PR TITLE
[15.0][IMP] tms: ease task dragging

### DIFF
--- a/tms/static/src/scss/kanban_view.scss
+++ b/tms/static/src/scss/kanban_view.scss
@@ -29,6 +29,10 @@
                 .o_kanban_header_title {
                     height: 100%;
                 }
+                &.o_kanban_hover {
+                    background-color: #e2e0eb !important;
+                    height: 80vh;
+                }
             }
         }
     }


### PR DESCRIPTION
Now we can highlight the droppable task and take space so the task group doesn't go away from our dragged kanban card

cc @Tecnativa TT40337