### PR TITLE
[15.0][FIX] tms: Add TMS Goods name required TT48470

### DIFF
--- a/tms/models/tms_goods.py
+++ b/tms/models/tms_goods.py
@@ -9,5 +9,5 @@ class TmsGoods(models.Model):
     _name = "tms.goods"
     _description = "TMS Goods"
 
-    name = fields.Char()
+    name = fields.Char(required=True)
     adr_id = fields.Many2one(comodel_name="tms.goods.adr", string="ADR")


### PR DESCRIPTION
- Before this change, user was able to create TMS Goods without information as many times as they want.
- Adding name required, forces the user to complete at least one field.

TT48470
@Tecnativa

@carlosdauden @sergio-teruel 